### PR TITLE
Feature/issue 6

### DIFF
--- a/lib/core/utils/app_toast.dart
+++ b/lib/core/utils/app_toast.dart
@@ -1,7 +1,7 @@
 import 'package:fluttertoast/fluttertoast.dart';
 import 'package:sufi_ishq/core/utils/constant.dart';
 
-class CustomToast {
+class AppToast {
   void showToast(String body, bool error) {
     Fluttertoast.showToast(
         msg: body,

--- a/lib/core/utils/constant.dart
+++ b/lib/core/utils/constant.dart
@@ -22,6 +22,9 @@ class Constant {
   static const double space10 = 10;
   static const double space15 = 15;
   static const double space20 = 20;
+  static const double space50 = 50;
 
   static const String fontUbuntu = "Ubuntu";
+  static const String dateFormat = "dd-MM-yyyy";
+  static const String dateFormatForApi = "yyyy-MM-dd";
 }

--- a/lib/core/utils/constant.dart
+++ b/lib/core/utils/constant.dart
@@ -6,6 +6,8 @@ class Constant {
   static const double appBarDivider = 2;
   static const double appBarHeight = 60;
   static const double fontSize14 = 14;
+  static const double fontSize16 = 16;
+  static const double fontSize24 = 24;
   static const double textScaleSize = 1.0;
   static const double playerHeight = 10;
   static const double rightTabBarWidth = 450;
@@ -17,6 +19,9 @@ class Constant {
   static const double themeToggleSize0 = 0;
   static const double themeToggleSize60 = 55;
   static const double themeToggleWidth = 110;
+  static const double space10 = 10;
+  static const double space15 = 15;
+  static const double space20 = 20;
 
   static const String fontUbuntu = "Ubuntu";
 }

--- a/lib/core/utils/custom_toast.dart
+++ b/lib/core/utils/custom_toast.dart
@@ -1,0 +1,13 @@
+import 'package:fluttertoast/fluttertoast.dart';
+import 'package:sufi_ishq/core/utils/constant.dart';
+
+class CustomToast {
+  void showToast(String body, bool error) {
+    Fluttertoast.showToast(
+        msg: body,
+        toastLength: Toast.LENGTH_LONG,
+        gravity: ToastGravity.BOTTOM,
+        timeInSecForIosWeb: 1,
+        fontSize: Constant.fontSize14);
+  }
+}

--- a/lib/core/utils/image_constant.dart
+++ b/lib/core/utils/image_constant.dart
@@ -13,4 +13,5 @@ class ImageConstant {
   static const String imgHpLogo = 'images/hp_logo.png';
   static const String imgDay = 'images/day.png';
   static const String imgNight = 'images/night.png';
+  static const String imgPattern = 'images/pattern.png';
 }

--- a/lib/core/utils/image_constant.dart
+++ b/lib/core/utils/image_constant.dart
@@ -13,5 +13,4 @@ class ImageConstant {
   static const String imgHpLogo = 'images/hp_logo.png';
   static const String imgDay = 'images/day.png';
   static const String imgNight = 'images/night.png';
-  static const String imgPattern = 'images/pattern.png';
 }

--- a/lib/core/utils/initial_bindings.dart
+++ b/lib/core/utils/initial_bindings.dart
@@ -1,9 +1,11 @@
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sufi_ishq/core/app_export.dart';
+import 'package:sufi_ishq/service/api_provider.dart';
 
 class InitialBindings extends Bindings {
   @override
   void dependencies() {
+    Get.lazyPut(() => APIProvider());
     Get.putAsync<SharedPreferences>(() async {
       final prefs = await SharedPreferences.getInstance();
       return prefs;

--- a/lib/core/utils/local_db_key.dart
+++ b/lib/core/utils/local_db_key.dart
@@ -1,3 +1,4 @@
 class LocalDBKeys {
-  static const String theme = "TOKEN";
+  static const String theme = "THEME";
+  static const String hijriDate = "HIJRIDATE";
 }

--- a/lib/core/utils/skeleton.dart
+++ b/lib/core/utils/skeleton.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+class Skeleton extends StatefulWidget {
+  final double height;
+  final double width;
+  final double cornerRadius;
+
+  Skeleton({
+    Key? key,
+    this.height = 20,
+    this.width = 200,
+    this.cornerRadius = 4,
+  }) : super(key: key);
+
+  @override
+  _SkeletonState createState() => _SkeletonState();
+}
+
+class _SkeletonState extends State<Skeleton>
+    with SingleTickerProviderStateMixin {
+  AnimationController? _controller;
+
+  Animation? gradientPosition;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 1500),
+      vsync: this,
+    );
+
+    gradientPosition = Tween<double>(
+      begin: -3,
+      end: 10,
+    ).animate(
+      CurvedAnimation(parent: _controller!, curve: Curves.linear),
+    )..addListener(
+        () {
+          setState(() {});
+        },
+      );
+
+    _controller!.repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller!.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: widget.width,
+      height: widget.height,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(widget.cornerRadius),
+        gradient: LinearGradient(
+          begin: Alignment(gradientPosition!.value, 0),
+          end: const Alignment(-1, 0),
+          colors: [
+            Color(0x0D000000),
+            Color(0x1A000000),
+            Color(0x0D000000),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/utils/widget_utils.dart
+++ b/lib/core/utils/widget_utils.dart
@@ -1,0 +1,7 @@
+import 'custom_toast.dart';
+
+class WidgetUtils {
+  static void showToast(String body, bool error) {
+    CustomToast().showToast(body, error);
+  }
+}

--- a/lib/core/utils/widget_utils.dart
+++ b/lib/core/utils/widget_utils.dart
@@ -1,7 +1,7 @@
-import 'custom_toast.dart';
+import 'app_toast.dart';
 
 class WidgetUtils {
   static void showToast(String body, bool error) {
-    CustomToast().showToast(body, error);
+    AppToast().showToast(body, error);
   }
 }

--- a/lib/generated_plugin_registrant.dart
+++ b/lib/generated_plugin_registrant.dart
@@ -8,6 +8,7 @@
 
 import 'package:connectivity_plus_web/connectivity_plus_web.dart';
 import 'package:firebase_core_web/firebase_core_web.dart';
+import 'package:fluttertoast/fluttertoast_web.dart';
 import 'package:package_info_plus/src/package_info_plus_web.dart';
 import 'package:shared_preferences_web/shared_preferences_web.dart';
 
@@ -17,6 +18,7 @@ import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 void registerPlugins(Registrar registrar) {
   ConnectivityPlusPlugin.registerWith(registrar);
   FirebaseCoreWeb.registerWith(registrar);
+  FluttertoastWebPlugin.registerWith(registrar);
   PackageInfoPlusWebPlugin.registerWith(registrar);
   SharedPreferencesPlugin.registerWith(registrar);
   registrar.registerMessageHandler();

--- a/lib/localization/en_us/en_us_translations.dart
+++ b/lib/localization/en_us/en_us_translations.dart
@@ -6,6 +6,7 @@ final Map<String, String> enUs = {
   'lbl_gallery': 'Gallery',
   'lbl_location': 'Location',
   'lbl_shijra': 'Shijra',
+  'lbl_request_time_out': 'Request time out',
   'lbl_themes': 'Themes',
   'lbl_help': 'Help',
   'lbl_admin_setting': 'Admin Setting',

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,8 +19,15 @@ void main() async {
   });
 }
 
-class SufiIshqApp extends StatelessWidget {
+class SufiIshqApp extends StatefulWidget {
   const SufiIshqApp({Key? key}) : super(key: key);
+
+  @override
+  _SufiIshqAppState createState() => _SufiIshqAppState();
+
+}
+
+class _SufiIshqAppState extends State<SufiIshqApp> {
 
   @override
   Widget build(BuildContext context) {
@@ -34,7 +41,7 @@ class SufiIshqApp extends StatelessWidget {
       fallbackLocale: const Locale('en', 'US'),
       title: 'lbl_sufi_ishq'.tr,
       initialBinding: InitialBindings(),
-      initialRoute: AppRoutes.initialRoute,
+      initialRoute: AppRoutes.dashboardScreen,
       getPages: AppRoutes.pages,
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,11 +24,9 @@ class SufiIshqApp extends StatefulWidget {
 
   @override
   _SufiIshqAppState createState() => _SufiIshqAppState();
-
 }
 
 class _SufiIshqAppState extends State<SufiIshqApp> {
-
   @override
   Widget build(BuildContext context) {
     return GetMaterialApp(

--- a/lib/presentation/dashboard_screen/widget/side_menu_item.dart
+++ b/lib/presentation/dashboard_screen/widget/side_menu_item.dart
@@ -41,7 +41,7 @@ class SideMenuItem extends StatelessWidget {
                   child: Text(title,
                       overflow: TextOverflow.ellipsis,
                       textAlign: TextAlign.left,
-                      style: AppStyle.txtUbuntuRegular16w500.copyWith(
+                      style: AppStyle.txtUbuntuRegular14w500.copyWith(
                           color: getForegroundColor(
                               ColorInitializer.background, context))),
                 )

--- a/lib/presentation/home_screen/controller/home_controller.dart
+++ b/lib/presentation/home_screen/controller/home_controller.dart
@@ -3,14 +3,18 @@ import 'package:get/get.dart';
 import 'package:sufi_ishq/core/utils/constant.dart';
 import 'package:sufi_ishq/core/utils/local_db_key.dart';
 import 'package:sufi_ishq/core/utils/pref_utils.dart';
+import 'package:sufi_ishq/presentation/home_screen/repository/home_repository.dart';
+import 'package:sufi_ishq/service/api_constant.dart';
 
 class HomeController extends GetxController {
+  final HomeRepository _repository = HomeRepository();
   RxBool isLightTheme = false.obs;
   Rx<double> width = 0.0.obs;
   @override
   Future<void> onReady() async {
     super.onReady();
     getThemeStatus();
+    callHijriDateApi();
   }
 
   saveThemeStatus() async {
@@ -22,5 +26,13 @@ class HomeController extends GetxController {
     isLightTheme.value = await isLight;
     Get.changeThemeMode(isLightTheme.value ? ThemeMode.light : ThemeMode.dark);
     isLightTheme.value ? Constant.themeToggleSize0 : Constant.themeToggleSize60;
+  }
+
+  void callHijriDateApi() async {
+    var value =
+        await _repository.fetchHijriDate(ApiConstant.hijriApiUrl, "08-04-2023");
+    if (!value.isError) {
+      print(value);
+    }
   }
 }

--- a/lib/presentation/home_screen/controller/home_controller.dart
+++ b/lib/presentation/home_screen/controller/home_controller.dart
@@ -29,10 +29,10 @@ class HomeController extends GetxController {
   }
 
   void callHijriDateApi() async {
-    var value =
-        await _repository.fetchHijriDate(ApiConstant.hijriApiUrl, "08-04-2023");
-    if (!value.isError) {
-      print(value);
-    }
+
+        await _repository.fetchHijriDate(ApiConstant.hijriApiUrl, "08-04-2023").then((value) => {
+        print("farhan response: $value"),
+        });
+
   }
 }

--- a/lib/presentation/home_screen/home_screen.dart
+++ b/lib/presentation/home_screen/home_screen.dart
@@ -18,11 +18,6 @@ class HomeScreen extends StatelessWidget {
         body: Container(
           decoration: BoxDecoration(
             color: getBackgroundColor(ColorInitializer.surface, context),
-           /* image: const DecorationImage(
-              scale: 2,
-              image: AssetImage(ImageConstant.imgPattern),
-              repeat: ImageRepeat.repeat,
-            ),*/
           ),
           child: Column(
             children: [
@@ -38,7 +33,8 @@ class HomeScreen extends StatelessWidget {
                     ),
                     controller.width.value < Constant.mobileSize
                         ? Container()
-                        : Expanded(child: HijriCalender()),
+                        : Expanded(
+                            child: HijriCalender(controller.hijriDateModel)),
                     const SizedBox(
                       width: Constant.space15,
                     ),

--- a/lib/presentation/home_screen/home_screen.dart
+++ b/lib/presentation/home_screen/home_screen.dart
@@ -18,11 +18,11 @@ class HomeScreen extends StatelessWidget {
         body: Container(
           decoration: BoxDecoration(
             color: getBackgroundColor(ColorInitializer.surface, context),
-            image: const DecorationImage(
+           /* image: const DecorationImage(
               scale: 2,
               image: AssetImage(ImageConstant.imgPattern),
               repeat: ImageRepeat.repeat,
-            ),
+            ),*/
           ),
           child: Column(
             children: [

--- a/lib/presentation/home_screen/home_screen.dart
+++ b/lib/presentation/home_screen/home_screen.dart
@@ -2,25 +2,46 @@ import 'package:flutter/material.dart';
 import 'package:sufi_ishq/core/app_export.dart';
 import 'package:sufi_ishq/core/utils/constant.dart';
 import 'package:sufi_ishq/presentation/home_screen/controller/home_controller.dart';
+import 'package:sufi_ishq/presentation/home_screen/widget/hijri_calender.dart';
+import 'package:sufi_ishq/presentation/home_screen/widget/overflow_menu.dart';
 import 'package:sufi_ishq/presentation/home_screen/widget/theme_toggle.dart';
 import 'package:sufi_ishq/theme/color_initializer.dart';
 
 class HomeScreen extends StatelessWidget {
   final HomeController controller = Get.put(HomeController());
+
   @override
   Widget build(BuildContext context) {
     controller.width.value = MediaQuery.of(context).size.width;
     return SafeArea(
       child: Scaffold(
         body: Container(
-          color: getBackgroundColor(ColorInitializer.surface, context),
+          decoration: BoxDecoration(
+            color: getBackgroundColor(ColorInitializer.surface, context),
+            image: const DecorationImage(
+              scale: 2,
+              image: AssetImage(ImageConstant.imgPattern),
+              repeat: ImageRepeat.repeat,
+            ),
+          ),
           child: Column(
             children: [
               Padding(
-                padding: const EdgeInsets.all(15.0),
+                padding: const EdgeInsets.all(Constant.space15),
                 child: Row(
                   children: [
-                    const Spacer(),
+                    controller.width.value < Constant.mobileSize
+                        ? Container()
+                        : OverflowMenu(),
+                    const SizedBox(
+                      width: Constant.space15,
+                    ),
+                    controller.width.value < Constant.mobileSize
+                        ? Container()
+                        : Expanded(child: HijriCalender()),
+                    const SizedBox(
+                      width: Constant.space15,
+                    ),
                     controller.width.value < Constant.mobileSize
                         ? Container()
                         : ThemeToggle(),

--- a/lib/presentation/home_screen/model/hijri_date_model.dart
+++ b/lib/presentation/home_screen/model/hijri_date_model.dart
@@ -1,0 +1,131 @@
+class HijriDateModel {
+  int? code;
+  String? status;
+  Data? data;
+
+  HijriDateModel({this.code, this.status, this.data});
+
+  HijriDateModel.fromJson(Map<String, dynamic> json) {
+    code = json['code'];
+    status = json['status'];
+    data = json['data'] != null ? Data.fromJson(json['data']) : null;
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['code'] = code;
+    data['status'] = status;
+    if (this.data != null) {
+      data['data'] = this.data!.toJson();
+    }
+    return data;
+  }
+}
+
+class Data {
+  Hijri? hijri;
+  Hijri? gregorian;
+
+  Data({this.hijri, this.gregorian});
+
+  Data.fromJson(Map<String, dynamic> json) {
+    hijri = json['hijri'] != null ? Hijri.fromJson(json['hijri']) : null;
+    gregorian =
+        json['gregorian'] != null ? Hijri.fromJson(json['gregorian']) : null;
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    if (hijri != null) {
+      data['hijri'] = hijri!.toJson();
+    }
+    if (gregorian != null) {
+      data['gregorian'] = gregorian!.toJson();
+    }
+    return data;
+  }
+}
+
+class Hijri {
+  String? date;
+  String? format;
+  String? day;
+  Month? month;
+  String? year;
+  Designation? designation;
+
+  Hijri(
+      {this.date,
+      this.format,
+      this.day,
+      this.month,
+      this.year,
+      this.designation});
+
+  Hijri.fromJson(Map<String, dynamic> json) {
+    date = json['date'];
+    format = json['format'];
+    day = json['day'];
+    month = json['month'] != null ? Month.fromJson(json['month']) : null;
+    year = json['year'];
+    designation = json['designation'] != null
+        ? Designation.fromJson(json['designation'])
+        : null;
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['date'] = date;
+    data['format'] = format;
+    data['day'] = day;
+    if (month != null) {
+      data['month'] = month!.toJson();
+    }
+    data['year'] = year;
+    if (designation != null) {
+      data['designation'] = designation!.toJson();
+    }
+    return data;
+  }
+}
+
+class Month {
+  int? number;
+  String? en;
+  String? ar;
+
+  Month({this.number, this.en, this.ar});
+
+  Month.fromJson(Map<String, dynamic> json) {
+    number = json['number'];
+    en = json['en'];
+    ar = json['ar'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['number'] = number;
+    data['en'] = en;
+    data['ar'] = ar;
+    return data;
+  }
+}
+
+class Designation {
+  String? abbreviated;
+  String? expanded;
+
+  Designation({this.abbreviated, this.expanded});
+
+  Designation.fromJson(Map<String, dynamic> json) {
+    abbreviated = json['abbreviated'];
+    expanded = json['expanded'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['abbreviated'] = abbreviated;
+    data['expanded'] = expanded;
+    return data;
+  }
+}

--- a/lib/presentation/home_screen/model/hijri_date_model.dart
+++ b/lib/presentation/home_screen/model/hijri_date_model.dart
@@ -24,14 +24,15 @@ class HijriDateModel {
 
 class Data {
   Hijri? hijri;
-  Hijri? gregorian;
+  Gregorian? gregorian;
 
   Data({this.hijri, this.gregorian});
 
   Data.fromJson(Map<String, dynamic> json) {
     hijri = json['hijri'] != null ? Hijri.fromJson(json['hijri']) : null;
-    gregorian =
-        json['gregorian'] != null ? Hijri.fromJson(json['gregorian']) : null;
+    gregorian = json['gregorian'] != null
+        ? Gregorian.fromJson(json['gregorian'])
+        : null;
   }
 
   Map<String, dynamic> toJson() {
@@ -50,7 +51,7 @@ class Hijri {
   String? date;
   String? format;
   String? day;
-  Month? month;
+  HijriMonth? month;
   String? year;
   Designation? designation;
 
@@ -66,7 +67,7 @@ class Hijri {
     date = json['date'];
     format = json['format'];
     day = json['day'];
-    month = json['month'] != null ? Month.fromJson(json['month']) : null;
+    month = json['month'] != null ? HijriMonth.fromJson(json['month']) : null;
     year = json['year'];
     designation = json['designation'] != null
         ? Designation.fromJson(json['designation'])
@@ -89,14 +90,65 @@ class Hijri {
   }
 }
 
-class Month {
+class Gregorian {
+  String? date;
+  String? format;
+  String? day;
+  Weekday? weekday;
+  GregorianMonth? month;
+  String? year;
+  Designation? designation;
+
+  Gregorian(
+      {this.date,
+      this.format,
+      this.day,
+      this.weekday,
+      this.month,
+      this.year,
+      this.designation});
+
+  Gregorian.fromJson(Map<String, dynamic> json) {
+    date = json['date'];
+    format = json['format'];
+    day = json['day'];
+    weekday =
+        json['weekday'] != null ? Weekday.fromJson(json['weekday']) : null;
+    month =
+        json['month'] != null ? GregorianMonth.fromJson(json['month']) : null;
+    year = json['year'];
+    designation = json['designation'] != null
+        ? Designation.fromJson(json['designation'])
+        : null;
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['date'] = date;
+    data['format'] = format;
+    data['day'] = day;
+    if (this.weekday != null) {
+      data['weekday'] = this.weekday!.toJson();
+    }
+    if (month != null) {
+      data['month'] = month!.toJson();
+    }
+    data['year'] = year;
+    if (designation != null) {
+      data['designation'] = designation!.toJson();
+    }
+    return data;
+  }
+}
+
+class HijriMonth {
   int? number;
   String? en;
   String? ar;
 
-  Month({this.number, this.en, this.ar});
+  HijriMonth({this.number, this.en, this.ar});
 
-  Month.fromJson(Map<String, dynamic> json) {
+  HijriMonth.fromJson(Map<String, dynamic> json) {
     number = json['number'];
     en = json['en'];
     ar = json['ar'];
@@ -107,6 +159,41 @@ class Month {
     data['number'] = number;
     data['en'] = en;
     data['ar'] = ar;
+    return data;
+  }
+}
+
+class GregorianMonth {
+  int? number;
+  String? en;
+
+  GregorianMonth({this.number, this.en});
+
+  GregorianMonth.fromJson(Map<String, dynamic> json) {
+    number = json['number'];
+    en = json['en'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['number'] = this.number;
+    data['en'] = this.en;
+    return data;
+  }
+}
+
+class Weekday {
+  String? en;
+
+  Weekday({this.en});
+
+  Weekday.fromJson(Map<String, dynamic> json) {
+    en = json['en'];
+  }
+
+  Map<String, dynamic> toJson() {
+    final Map<String, dynamic> data = <String, dynamic>{};
+    data['en'] = this.en;
     return data;
   }
 }

--- a/lib/presentation/home_screen/repository/home_repository.dart
+++ b/lib/presentation/home_screen/repository/home_repository.dart
@@ -1,0 +1,8 @@
+import 'package:sufi_ishq/service/base_services.dart';
+
+class HomeRepository {
+  final BaseService _baseService = BaseService();
+
+  Future fetchHijriDate(url, endPoint) async =>
+      _baseService.getHijriDate(url: url, endpoint: endPoint);
+}

--- a/lib/presentation/home_screen/widget/hijri_calender.dart
+++ b/lib/presentation/home_screen/widget/hijri_calender.dart
@@ -2,11 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:sufi_ishq/core/app_export.dart';
 import 'package:sufi_ishq/core/utils/constant.dart';
 import 'package:sufi_ishq/presentation/home_screen/controller/home_controller.dart';
+import 'package:sufi_ishq/presentation/home_screen/model/hijri_date_model.dart';
 import 'package:sufi_ishq/theme/app_style.dart';
 import 'package:sufi_ishq/theme/color_initializer.dart';
 
+import '../../../core/utils/skeleton.dart';
+
 class HijriCalender extends StatelessWidget {
-  HijriCalender({Key? key}) : super(key: key);
+  HijriCalender(this.model, {Key? key}) : super(key: key);
+  Rx<HijriDateModel> model;
   final HomeController controller = Get.find<HomeController>();
 
   @override
@@ -31,32 +35,58 @@ class HijriCalender extends StatelessWidget {
               const SizedBox(
                 width: Constant.space10,
               ),
-              Text("1444 hijri",
-                  overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.left,
-                  style: AppStyle.txtUbuntuRegular14w500.copyWith(
-                      color: getForegroundColor(
-                          ColorInitializer.secondary, context))),
+              Obx(
+                () => model.value.data != null
+                    ? Text("${model.value.data!.hijri!.year} hijri",
+                        overflow: TextOverflow.ellipsis,
+                        textAlign: TextAlign.left,
+                        style: AppStyle.txtUbuntuRegular14w500.copyWith(
+                            color: getForegroundColor(
+                                ColorInitializer.secondary, context)))
+                    : SizedBox(
+                        width: Constant.space50,
+                        height: Constant.space20,
+                        child: Skeleton(),
+                      ),
+              ),
               const Spacer(),
-              Text("صَفَر",
-                  overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.left,
-                  style: AppStyle.txtUbuntuRegular18w500.copyWith(
-                      color: getForegroundColor(
-                          ColorInitializer.secondary, context))),
-              Text(" 26",
-                  overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.left,
-                  style: AppStyle.txtUbuntuRegular18w500.copyWith(
-                      color: getForegroundColor(
-                          ColorInitializer.secondary, context))),
+              model.value.data != null
+                  ? Text("${model.value.data!.hijri!.month!.ar}",
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.left,
+                      style: AppStyle.txtUbuntuRegular18w500.copyWith(
+                          color: getForegroundColor(
+                              ColorInitializer.secondary, context)))
+                  : SizedBox(
+                      width: Constant.space50,
+                      height: Constant.space20,
+                      child: Skeleton(),
+                    ),
+              model.value.data != null
+                  ? Text(" ${model.value.data!.hijri!.day!}",
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.left,
+                      style: AppStyle.txtUbuntuRegular18w500.copyWith(
+                          color: getForegroundColor(
+                              ColorInitializer.secondary, context)))
+                  : SizedBox(
+                      width: Constant.space50,
+                      height: Constant.space20,
+                      child: Skeleton(),
+                    ),
               const Spacer(),
-              Text("Sunday",
-                  overflow: TextOverflow.ellipsis,
-                  textAlign: TextAlign.left,
-                  style: AppStyle.txtUbuntuRegular14w500.copyWith(
-                      color: getForegroundColor(
-                          ColorInitializer.secondary, context))),
+              model.value.data != null
+                  ? Text("${model.value.data!.gregorian!.weekday!.en}",
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.left,
+                      style: AppStyle.txtUbuntuRegular14w500.copyWith(
+                          color: getForegroundColor(
+                              ColorInitializer.secondary, context)))
+                  : SizedBox(
+                      width: Constant.space50,
+                      height: Constant.space20,
+                      child: Skeleton(),
+                    ),
               const SizedBox(
                 width: Constant.space10,
               )

--- a/lib/presentation/home_screen/widget/hijri_calender.dart
+++ b/lib/presentation/home_screen/widget/hijri_calender.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:sufi_ishq/core/app_export.dart';
+import 'package:sufi_ishq/core/utils/constant.dart';
+import 'package:sufi_ishq/presentation/home_screen/controller/home_controller.dart';
+import 'package:sufi_ishq/theme/app_style.dart';
+import 'package:sufi_ishq/theme/color_initializer.dart';
+
+class HijriCalender extends StatelessWidget {
+  HijriCalender({Key? key}) : super(key: key);
+  final HomeController controller = Get.find<HomeController>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Container(
+          height: Constant.themeToggleSize60,
+          decoration: BoxDecoration(
+            color: getBackgroundColor(ColorInitializer.secondary, context),
+            borderRadius: BorderRadius.circular(3.0),
+            boxShadow: [
+              BoxShadow(
+                color: getBackgroundColor(ColorInitializer.primary, context),
+                spreadRadius: 1,
+                blurRadius: 1, // changes position of shadow
+              ),
+            ],
+          ),
+          child: Row(
+            children: [
+              const SizedBox(
+                width: Constant.space10,
+              ),
+              Text("1444 hijri",
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.left,
+                  style: AppStyle.txtUbuntuRegular14w500.copyWith(
+                      color: getForegroundColor(
+                          ColorInitializer.secondary, context))),
+              const Spacer(),
+              Text("صَفَر",
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.left,
+                  style: AppStyle.txtUbuntuRegular18w500.copyWith(
+                      color: getForegroundColor(
+                          ColorInitializer.secondary, context))),
+              Text(" 26",
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.left,
+                  style: AppStyle.txtUbuntuRegular18w500.copyWith(
+                      color: getForegroundColor(
+                          ColorInitializer.secondary, context))),
+              const Spacer(),
+              Text("Sunday",
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.left,
+                  style: AppStyle.txtUbuntuRegular14w500.copyWith(
+                      color: getForegroundColor(
+                          ColorInitializer.secondary, context))),
+              const SizedBox(
+                width: Constant.space10,
+              )
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/home_screen/widget/overflow_menu.dart
+++ b/lib/presentation/home_screen/widget/overflow_menu.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:sufi_ishq/core/app_export.dart';
+import 'package:sufi_ishq/core/utils/constant.dart';
+import 'package:sufi_ishq/presentation/home_screen/controller/home_controller.dart';
+import 'package:sufi_ishq/theme/color_initializer.dart';
+
+class OverflowMenu extends StatelessWidget {
+  OverflowMenu({Key? key}) : super(key: key);
+  final HomeController controller = Get.find<HomeController>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Container(
+          width: Constant.themeToggleSize60,
+          height: Constant.themeToggleSize60,
+          decoration: BoxDecoration(
+            color: getBackgroundColor(ColorInitializer.background, context),
+            borderRadius: BorderRadius.circular(3.0),
+            boxShadow: [
+              BoxShadow(
+                color: getBackgroundColor(ColorInitializer.primary, context),
+                spreadRadius: 1,
+                blurRadius: 1, // changes position of shadow
+              ),
+            ],
+          ),
+          child: const Icon(
+            Icons.more_vert_outlined,
+            size: Constant.menuIconSize24,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -7,7 +7,6 @@ import 'package:sufi_ishq/presentation/home_screen/home_screen.dart';
 class AppRoutes {
   static const String homeScreen = '/home_screen';
   static const String dashboardScreen = '/dashboard_screen';
-  static String initialRoute = '/initial_route';
 
   static List<GetPage> pages = [
     GetPage(
@@ -24,12 +23,5 @@ class AppRoutes {
         DashboardBinding(),
       ],
     ),
-    GetPage(
-      name: initialRoute,
-      page: () => DashboardScreen(),
-      bindings: [
-        DashboardBinding(),
-      ],
-    )
   ];
 }

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -5,7 +5,6 @@ import 'package:sufi_ishq/presentation/home_screen/binding/home_binding.dart';
 import 'package:sufi_ishq/presentation/home_screen/home_screen.dart';
 
 class AppRoutes {
-  static const String splashScreen = '/splash_screen';
   static const String homeScreen = '/home_screen';
   static const String dashboardScreen = '/dashboard_screen';
   static String initialRoute = '/initial_route';

--- a/lib/service/api_constant.dart
+++ b/lib/service/api_constant.dart
@@ -1,0 +1,5 @@
+class ApiConstant {
+  static const String hijriApiUrl = "http://api.aladhan.com/v1/hToG/";
+
+  static const int requestDuration = 60;
+}

--- a/lib/service/api_constant.dart
+++ b/lib/service/api_constant.dart
@@ -1,5 +1,5 @@
 class ApiConstant {
-  static const String hijriApiUrl = "http://api.aladhan.com/v1/hToG/";
+  static const String hijriApiUrl = "http://api.aladhan.com/v1/gToH/";
 
   static const int requestDuration = 60;
 }

--- a/lib/service/api_provider.dart
+++ b/lib/service/api_provider.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-
 import 'package:get/get_connect/connect.dart';
 import 'package:http/http.dart' as http;
 import 'package:sufi_ishq/core/utils/widget_utils.dart';
@@ -11,8 +10,8 @@ class APIProvider extends GetConnect {
       {successMsg, loading, status}) async {
     http.Response response;
     try {
-      response = await http.get(Uri.parse(url + endpoint), headers: {
-      }).timeout(const Duration(seconds: ApiConstant.requestDuration));
+      response = await http.get(Uri.parse(url + endpoint), headers: {}).timeout(
+          const Duration(seconds: ApiConstant.requestDuration));
 
       if (status != null) {
         return response.statusCode;

--- a/lib/service/api_provider.dart
+++ b/lib/service/api_provider.dart
@@ -1,0 +1,48 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:get/get_connect/connect.dart';
+import 'package:http/http.dart' as http;
+import 'package:sufi_ishq/core/utils/widget_utils.dart';
+import 'package:sufi_ishq/service/api_constant.dart';
+
+class APIProvider extends GetConnect {
+  Future getHijriDate(String url, String endpoint,
+      {successMsg, loading, status}) async {
+    http.Response response;
+    try {
+      response = await http.get(Uri.parse(url + endpoint), headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "POST, GET, OPTIONS, DELETE",
+        "Origin": "http://localhost"
+      }).timeout(const Duration(seconds: ApiConstant.requestDuration));
+
+      print(response.body);
+
+      if (status != null) {
+        return response.statusCode;
+      }
+
+      dynamic jsonData;
+      if (response.statusCode == 200) {
+        jsonData = json.decode(response.body);
+        return jsonData;
+      } else if (response.statusCode == 401) {
+        jsonData = json.decode(response.body);
+        return jsonData;
+      } else if (response.statusCode == 403) {
+        jsonData = json.decode(response.body);
+        return jsonData;
+      } else {
+        jsonData = json.decode(response.body);
+        return jsonData;
+      }
+    } on TimeoutException catch (_) {
+      WidgetUtils.showToast('Request time out', true);
+      return false;
+    } catch (socketException) {
+      print(socketException);
+      return false;
+    }
+  }
+}

--- a/lib/service/api_provider.dart
+++ b/lib/service/api_provider.dart
@@ -12,12 +12,7 @@ class APIProvider extends GetConnect {
     http.Response response;
     try {
       response = await http.get(Uri.parse(url + endpoint), headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "POST, GET, OPTIONS, DELETE",
-        "Origin": "http://localhost"
       }).timeout(const Duration(seconds: ApiConstant.requestDuration));
-
-      print(response.body);
 
       if (status != null) {
         return response.statusCode;

--- a/lib/service/base_services.dart
+++ b/lib/service/base_services.dart
@@ -1,0 +1,12 @@
+import 'dart:async';
+
+import 'package:get/get.dart';
+import 'package:sufi_ishq/service/api_provider.dart';
+
+class BaseService {
+  final APIProvider _apiProvider = GetInstance().find<APIProvider>();
+
+  Future getHijriDate({required String url, required String endpoint}) async {
+    return await _apiProvider.getHijriDate(url, endpoint);
+  }
+}

--- a/lib/theme/app_style.dart
+++ b/lib/theme/app_style.dart
@@ -2,8 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:sufi_ishq/core/utils/constant.dart';
 
 class AppStyle {
-  static TextStyle txtUbuntuRegular16w500 = const TextStyle(
+  static TextStyle txtUbuntuRegular14w500 = const TextStyle(
       fontFamily: Constant.fontUbuntu,
       fontWeight: FontWeight.w500,
       fontSize: Constant.fontSize14);
+
+  static TextStyle txtUbuntuRegular18w500 = const TextStyle(
+      fontFamily: Constant.fontUbuntu,
+      fontWeight: FontWeight.w500,
+      fontSize: Constant.fontSize24);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -205,6 +205,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  fluttertoast:
+    dependency: "direct main"
+    description:
+      name: fluttertoast
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "8.2.1"
   get:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   connectivity_plus:
   shared_preferences:
   drift:
+  fluttertoast:
   package_info_plus:
   flutter_svg:
   floor:

--- a/web/index.html
+++ b/web/index.html
@@ -14,7 +14,7 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="/">
+ <!-- <base href="/">-->
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">

--- a/web/index.html
+++ b/web/index.html
@@ -14,7 +14,7 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-  <base href="$FLUTTER_BASE_HREF">
+  <base href="/">
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
@@ -29,7 +29,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>sufiishq_webapp</title>
+  <title>Sufi Ishq</title>
   <link rel="manifest" href="manifest.json">
 
   <script>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "sufiishq_webapp",
-    "short_name": "sufiishq_webapp",
+    "name": "Sufi Ishq",
+    "short_name": "Sufi Ishq",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",


### PR DESCRIPTION
Fixes: #6 

This PR is about flexible hijri-date widget in the center of the header

Description
This PR adds flexible hijri-date widget in the center of the header:

Created repository and data source related classes to get the data from API.
Load hijri-date from the API and store it locally to avoid the subsequent call.
Call the API in the background if the stored date is not equal to Current Date.

Tested on Safari/Chrome Browser